### PR TITLE
use column 0 for :elixir.string_to_tokens/5

### DIFF
--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -116,7 +116,7 @@ defmodule OpenSCAD.Watcher do
   end
 
   defp string_to_quoted(string, start_line, file, opts) do
-    case :elixir.string_to_tokens(string, start_line, file, opts) do
+    case :elixir.string_to_tokens(string, start_line, 0, file, opts) do
       {:ok, tokens} ->
         :elixir.tokens_to_quoted(tokens, file, opts)
 


### PR DESCRIPTION
Looks like this undocumented function changed arity. I didn't chase down which version of elixir it changed in, but with my newer system with OpenSSLv3 I can't get the older Erlang versions to compile, so figured I'd patch this for new versions of Elixir.